### PR TITLE
Do not unpack jar files if bundle is already extracted to directory

### DIFF
--- a/osgi/framework/src/org/knopflerfish/framework/bundlestorage/file/Archive.java
+++ b/osgi/framework/src/org/knopflerfish/framework/bundlestorage/file/Archive.java
@@ -1239,6 +1239,8 @@ public class Archive implements FileArchive {
    * @exception IllegalArgumentException if we have a broken manifest.
    */
   private boolean needUnpack(Attributes a) {
+    if( fileIsReference && file.isDirectory())
+        return false;
     final List<HeaderEntry> nc = Util
         .parseManifestHeader(Constants.BUNDLE_NATIVECODE,
                              a.getValue(Constants.BUNDLE_NATIVECODE), false,


### PR DESCRIPTION
I tested the new knopflerfish version with Freeplane. Here we use readonly bundles already extracted into directories and still containing some jar files which do not need to be extracted themselves.

I used configuration
~~~~
-Dorg.knopflerfish.framework.readonly=true
-Dorg.knopflerfish.gosg.jars=reference:file:/path/to/freeplane/bundle/directory/
-Dorg.knopflerfish.framework.bundlestorage.file.unpack=false
~~~~
Knopflerfisch framework in Version 8.0.0 refused to start with message  `Framework is in read-only mode, we can not install bundles that needs to be downloaded (e.g. has native code or an internal Bundle-ClassPath)` that makes no sense. Therefore I am suggesting this correction.
