### PR TITLE
Avoid NoSuchElementException

### DIFF
--- a/osgi/framework/src/org/knopflerfish/framework/BundleClassLoader.java
+++ b/osgi/framework/src/org/knopflerfish/framework/BundleClassLoader.java
@@ -209,7 +209,7 @@ final public class BundleClassLoader extends ClassLoader implements BundleRefere
   @Override
   protected URL findResource(String name) {
     final Enumeration<URL> res = getBundleResources(name, true);
-    if (res != null) {
+    if (res != null && res.hasMoreElements()) {
       return res.nextElement();
     } else {
       return null;


### PR DESCRIPTION
If bundle class loader should find a resource from package loaded by application class loader and this resource is not available, it currently throws NoSuchElementException instead of returning null.

~~~~
Exception in thread "main" 
java.util.NoSuchElementException
	at sun.misc.CompoundEnumeration.nextElement(CompoundEnumeration.java:59)
	at org.knopflerfish.framework.BundleClassLoader.findResource(BundleClassLoader.java:213)
	at org.knopflerfish.framework.BundleClassLoader.getResource(BundleClassLoader.java:391)
	at org.freeplane.launcher.Launcher.launchWithoutUICheck(Launcher.java:279)
~~~~

It happens because it delegates to application class loader

~~~~
<init>:39, CompoundEnumeration (sun.misc)
getResources:1144, ClassLoader (java.lang)
frameworkSearchFor:887, BundleClassLoader (org.knopflerfish.framework)
searchFor0:715, BundleClassLoader (org.knopflerfish.framework)
searchFor:613, BundleClassLoader (org.knopflerfish.framework)
run:561, SecurePermissionOps$3 (org.knopflerfish.framework)
doPrivileged:-1, AccessController (java.security)
callSearchFor:558, SecurePermissionOps (org.knopflerfish.framework)
getBundleResources:513, BundleClassLoader (org.knopflerfish.framework)
findResource:211, BundleClassLoader (org.knopflerfish.framework)
getResource:391, BundleClassLoader (org.knopflerfish.framework)
launchWithoutUICheck:279, Launcher (org.freeplane.launcher)
main:75, Launcher (org.freeplane.launcher)
~~~~
which can return non null enumeration which is empty.

The pull request adds a check for this case.